### PR TITLE
Alerter Credentials in config.yaml

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1900,15 +1900,21 @@ The alerter requires the following options:
 
 ``servicenow_rest_url``: The ServiceNow RestApi url, this will look like https://instancename.service-now.com/api/now/v1/table/incident
 
-``username``: The ServiceNow Username to access the api.
+``snow_username``: The ServiceNow Username to access the api.
 
-``password``: The ServiceNow password to access the api.
+``snow_password``: The ServiceNow password to access the api.
 
 ``short_description``: The ServiceNow password to access the api.
+
+Optional:
 
 ``comments``: Comments to be attached to the incident, this is the equivilant of work notes.
 
 ``assignment_group``: The group to assign the incident to.
+
+``Service Element (u_business_service)``: This is the 32-character long ID of the Service Element that will take care of theincident.
+
+``Functional Element (u_functional_element)``: The 32-character long ID of the FE that will take care of the incident.
 
 ``category``: The category to attach the incident to, use an existing category.
 
@@ -1917,9 +1923,6 @@ The alerter requires the following options:
 ``cmdb_ci``: The configuration item to attach the incident to.
 
 ``caller_id``: The caller id (email address) of the user that created the incident (elastalert@somewhere.com).
-
-
-Optional:
 
 ``servicenow_proxy``: By default ElastAlert will not use a network proxy to send notifications to ServiceNow. Set this option using ``hostname:port`` if you need to use a proxy.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1900,11 +1900,11 @@ The alerter requires the following options:
 
 ``servicenow_rest_url``: The ServiceNow RestApi url, this will look like https://instancename.service-now.com/api/now/v1/table/incident
 
-``snow_username``: The ServiceNow Username to access the api.
+``snow_username``: The ServiceNow Username to access the api. This option allows the rule to override the buffer_time global setting defined in config.yaml.
 
-``snow_password``: The ServiceNow password to access the api.
+``snow_password``: The ServiceNow password to access the api. This option allows the rule to override the buffer_time global setting defined in config.yaml.
 
-``short_description``: The ServiceNow password to access the api.
+``short_description``: The ServiceNow password to access the api. This option allows the rule to override the buffer_time global setting defined in config.yaml.
 
 Optional:
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1789,7 +1789,7 @@ class ServiceNowAlerter(Alerter):
 
         key_list = ["caller_id", "comments", "assignment_group", "category", "subcategory", "cmdb_ci", "comments", "u_business_service", "u_functional_element"]
 
-        payload = {"description": description}
+        payload = {"description": description, "short_description": self.rule['short_description']}
 
         for key in key_list:
             if (self.rule.get(key)):

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1764,16 +1764,10 @@ class GitterAlerter(Alerter):
 class ServiceNowAlerter(Alerter):
     """ Creates a ServiceNow alert """
     required_options = set([
-        'username',
-        'password',
+        'snow_username',
+        'snow_password',
         'servicenow_rest_url',
-        'short_description',
-        'comments',
-        'assignment_group',
-        'category',
-        'subcategory',
-        'cmdb_ci',
-        'caller_id'
+        'short_description'
     ])
 
     def __init__(self, rule):
@@ -1792,20 +1786,19 @@ class ServiceNowAlerter(Alerter):
             "Accept": "application/json;charset=utf-8"
         }
         proxies = {'https': self.servicenow_proxy} if self.servicenow_proxy else None
-        payload = {
-            "description": description,
-            "short_description": self.rule['short_description'],
-            "comments": self.rule['comments'],
-            "assignment_group": self.rule['assignment_group'],
-            "category": self.rule['category'],
-            "subcategory": self.rule['subcategory'],
-            "cmdb_ci": self.rule['cmdb_ci'],
-            "caller_id": self.rule["caller_id"]
-        }
+
+        key_list = ["caller_id", "comments", "assignment_group", "category", "subcategory", "cmdb_ci", "comments", "u_business_service", "u_functional_element"]
+
+        payload = {"description": description}
+
+        for key in key_list:
+            if (self.rule.get(key)):
+                payload.update({key: self.rule[key]})
+
         try:
             response = requests.post(
                 self.servicenow_rest_url,
-                auth=(self.rule['username'], self.rule['password']),
+                auth=(self.rule['snow_username'], self.rule['snow_password']),
                 headers=headers,
                 data=json.dumps(payload, cls=DateTimeEncoder),
                 proxies=proxies

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -217,9 +217,12 @@ def load_options(rule, conf, filename, args=None):
         for key in required_credentials:
                 if key not in rule:
                     rule.update({key: conf[key]})
-    except (KeyError, TypeError) as e:
-        raise EAException('Missing required credentials: %s' % (e))
-
+    except:
+        missing_credentials = []
+        for key in required_credentials:
+            if key not in conf:
+                missing_credentials.append(key)
+        raise EAException('Missing required credentials: %s' % (missing_credentials))
 
     # Set defaults, copy defaults from config.yaml
     td_fields = ['realert', 'exponential_realert', 'aggregation', 'query_delay']

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -33,7 +33,7 @@ rule_schema = jsonschema.Draft4Validator(yaml.load(open(os.path.join(os.path.dir
 # Required global (config.yaml) and local (rule.yaml)  configuration options
 required_globals = frozenset(['run_every', 'rules_folder', 'es_host', 'es_port', 'writeback_index', 'buffer_time'])
 required_locals = frozenset(['alert', 'type', 'name', 'index'])
-required_credentials = frozenset(['snow_username', 'snow_password'])
+required_credentials = frozenset(['snow_username', 'snow_password', 'servicenow_rest_url'])
 
 # Settings that can be derived from ENV variables
 env_settings = {'ES_USE_SSL': 'use_ssl',

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -33,6 +33,7 @@ rule_schema = jsonschema.Draft4Validator(yaml.load(open(os.path.join(os.path.dir
 # Required global (config.yaml) and local (rule.yaml)  configuration options
 required_globals = frozenset(['run_every', 'rules_folder', 'es_host', 'es_port', 'writeback_index', 'buffer_time'])
 required_locals = frozenset(['alert', 'type', 'name', 'index'])
+required_credentials = frozenset(['snow_username', 'snow_password'])
 
 # Settings that can be derived from ENV variables
 env_settings = {'ES_USE_SSL': 'use_ssl',
@@ -210,6 +211,15 @@ def load_options(rule, conf, filename, args=None):
             rule['kibana4_end_timedelta'] = datetime.timedelta(**rule['kibana4_end_timedelta'])
     except (KeyError, TypeError) as e:
         raise EAException('Invalid time format used: %s' % (e))
+
+    # Copy required_credentials from config.yaml
+    try:
+        for key in required_credentials:
+                if key not in rule:
+                    rule.update({key: conf[key]})
+    except (KeyError, TypeError) as e:
+        raise EAException('Missing required credentials: %s' % (e))
+
 
     # Set defaults, copy defaults from config.yaml
     td_fields = ['realert', 'exponential_realert', 'aggregation', 'query_delay']


### PR DESCRIPTION
These modifications allow us to have a more generic service now alerter, with 
required parameters the:
* snow api url
* snow_username
* snow_password
* short-description

The rest are optional and can be define per purpose of usage.

Also the credentials can be used in config.yaml / inside the rule as whatever user prefers. If they are configured in both places then the definitions of the rule aelrter credential is kept for convenience with the original release